### PR TITLE
feat(scope): add allowlist regex support and scoped crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,22 @@ A basic, endpoint crawler for authorized testing. Created as a skeleton to conti
 - **Breadth-First Crawling** to visit pages, extract links and save results
 - **JSON output** for easy readability
 - Optional **Rate Limiting** for setting max pages 
+- **Regex Scope allowlisting** so only matching URLs are crawled
 
 ## Usage 
 ```bash 
 python the_crawler.py \
     --target https://theCruller.com \
-    --output crawler_result.json
-    --max-pages 3
+    --output crawler_basic.json
+    --max-pages 3 \
+    --scope-file scope_allowlist.txt
 ```
 
 ### Common Flags
 - `--target` : URL or domain to crawl (http/https)
 - `--output` : JSON file path 
 - `--max-pages` : Limit number of pages to crawl
+- `--scope-file` : Path to allowlist regex file
 
 ## Output 
 ``` json

--- a/scope_allowlist.txt
+++ b/scope_allowlist.txt
@@ -1,0 +1,3 @@
+# only crawl theCruller.com (example domain) and its API
+^https?://(www\.)?theCruller\.com(/.*)?$
+^https?://api\.theCruller\.com(/.*)?$

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,23 @@
+import re
+from src.vv_crawler.the_crawler import in_scope, load_allowlist
+
+def test_in_scope_patterns():
+    allow = [re.compile(r"^https?://(www\.)?theCruller\.com(/.*)?$")]
+    assert in_scope("http://theCruller.com/", allow) is True
+    assert in_scope("https://www.theCruller.com/a/b", allow) is True
+    assert in_scope("https://theCrawler.com/", allow) is False
+
+def test_empty_allowlist_defaults_true():
+    assert in_scope("http://theCruller.com/", []) is True
+
+def test_load_allowlist(tmp_path):
+    p =tmp_path / "scope.txt"
+    p.write_text("""
+# comment
+^https?://(www\\.)?theCruller\\.com(/.*)?$
+                 
+""", encoding="utf-8")
+    pats = load_allowlist(str(p))
+    assert len(pats) == 1
+    assert in_scope("https://theCruller.com/x", pats) is True
+    assert in_scope("https://theCrawler.com", pats) is False


### PR DESCRIPTION
### 🧩 What
- Added scope allowlist support via `--scope-file` (regex per line).
- Implemented `load_allowlist()` and `in_scope()` helpers.
- Enforced scoped crawling after same-host filtering.
- Added `scope_allowlist.txt` example and README docs.
- New tests for scope parsing and matching.
---
### 🧠 Why
- Prevents accidental off-scope crawling and makes behavior explicit and auditable.
---
### 🧪 How to test
1. Run unit tests:
   ```bash
   PYTHONPATH="$PWD" pytest -q

2. Manual check (authorized target):

   ```bash
   python -m automation_scripts.crawler.the_crawler \
     --target https://example.com \
     --scope-file scope_allowlist.txt \
     --max-pages 5 --debug
---
### ✅ Review checklist

- [x]  Scope file is optional; default remains same-host only.
- [x]  Invalid regex lines raise a clear error.
- [x]  Unit tests cover load_allowlist() and in_scope().
- [x]  README documents usage and example patterns.